### PR TITLE
Replace "ssg" with "vocabs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This part of the [SkoHub](http://skohub.io) project covers the need to easily pu
 
 ## Set up
 
-    $ git clone https://github.com/hbz/skohub-ssg.git
-    $ cd skohub-ssg
+    $ git clone https://github.com/hbz/skohub-vocabs.git
+    $ cd skohub-vocabs
     $ npm i
     $ cp .env.example .env
     $ cp test/data/systematik.ttl data/

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: `SkoHub-SSG`,
+    title: `SkoHub-Vocabs`,
     description: `Static site generator for Simple Knowledge Management Systems (SKOS)`,
     author: `@gatsbyjs`,
   },

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "skohub-ssg",
+  "name": "skohub-vocabs",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "skohub-ssg",
+  "name": "skohub-vocabs",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hbz/skohub-ssg.git"
+    "url": "git+https://github.com/hbz/skohub-vocabs.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/hbz/skohub-ssg/issues"
+    "url": "https://github.com/hbz/skohub-vocabs/issues"
   },
-  "homepage": "https://github.com/hbz/skohub-ssg#readme",
+  "homepage": "https://github.com/hbz/skohub-vocabs#readme",
   "dependencies": {
     "xml2js": "^0.4.19",
     "xmldom": "^0.1.27",


### PR DESCRIPTION
...as we renamed the application to "SkoHub Vocabs" (or "SkoHub-Vocabs"?). This PR replaces all occurences of "skohub-ssg" in this repo with "skohub-vocabs".