### PR TITLE
Fix Mastodon discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@ PORT=3000
 SECRET=YOUR_GITHUB_WEBHOOK_SECRET
 INBOX=https://test.skohub.io/inbox?target={id}
 FOLLOWERS=https://test.skohub.io/followers?subject={id}
-ACTOR=https://test.skohub.io{+path}
+ACTOR=https://test.skohub.io/{+path}
 PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyr05JFWnpFGTr423+IRU\nHOgAuoF0RSxdwPpvXbX5uh+2jUBvhXzzklhc5nwfE3XruHTifJWyXFWucJlDPEI1\nxR5p0C0zfqY74ioEoKorifc8no8ZDTQRvIIEqNe0Ezbe085Foc3UWG1kimPcPlqU\nnsgCYgO4UWJ27qABE+yGDykZALdMlAt+dwOPD10NcqmvupH5pgWZJJ9vW2ErTaDt\n2R52JIpqH6CvCsI7jpLyYH60W0N0J0sjSH95lZnyVDYDbplIEPUPpGKYSVJW+dNU\nCxReZBiwS76VDQhyl1lT5JusRCogvsX/bwJrIZ8fJcOBArDx2skknzUHKkjNITsD\nTwIDAQAB\n-----END PUBLIC KEY-----\n"
 BUILD_URL=https://test.skohub.io/build

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -82,10 +82,10 @@ exports.sourceNodes = async ({
       if (type === 'Concept') {
         Object.assign(node, {
          followers: followersUrlTemplate.expand({
-           id: ((process.env.BASEURL || '') + getPath(node.id))
+           id: `${process.env.BASEURL || ''}/${getPath(node.id)}`.substr(1)
          }),
          inbox: inboxUrlTemplate.expand({
-           id: ((process.env.BASEURL || '') + getPath(node.id))
+           id: `${process.env.BASEURL || ''}/${getPath(node.id)}`.substr(1)
          })
        })
       }
@@ -110,7 +110,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
     conceptsInScheme.data.allConcept.edges.forEach(({ node: concept }) => {
       const json = omitEmpty(Object.assign({}, concept, context.jsonld))
       const jsonld = omitEmpty(Object.assign({}, concept, context.jsonld))
-      const actorPath = (process.env.BASEURL || '') + getPath(concept.id)
+      const actorPath = `${process.env.BASEURL || ''}/${getPath(concept.id)}`.substr(1)
       const actor = actorUrlTemplate.expand({ path: actorPath })
       const jsonas = omitEmpty({
         context: context.as,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -112,8 +112,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
       const jsonld = omitEmpty(Object.assign({}, concept, context.jsonld))
       const actorPath = `${process.env.BASEURL || ''}/${getPath(concept.id)}`.substr(1)
       const actor = actorUrlTemplate.expand({ path: actorPath })
-      const jsonas = omitEmpty({
-        context: context.as,
+      const jsonas = Object.assign(omitEmpty({
         id: actor,
         type: 'Service',
         name: t(concept.prefLabel),
@@ -125,7 +124,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
           owner: actor,
           publicKeyPem: process.env.PUBLIC_KEY
         }
-      })
+      }), context.as)
 
       if (getFilePath(concept.id) === getFilePath(conceptScheme.id)) {
         // embed concepts in concept scheme


### PR DESCRIPTION
Note the updated `ACTOR` environment variable which must now contain a slash before the `path`. Catching the second mistake, a wrong nested context property, was hard. This is obviously a lacking test case I should fix, but debugging the Mastodon interaction would also be easier if had our own (dev) instance running.

Fixes https://github.com/hbz/skohub-pubsub/issues/35